### PR TITLE
Add /summit route + UTM attribution capture (closes #9)

### DIFF
--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -6,7 +6,20 @@ import { t, isValidLang, type Lang } from '@/lib/i18n'
 
 export async function POST(req: Request) {
   try {
-    const { fullName, email, country, zipCode, lang = 'en' } = await req.json()
+    const {
+      fullName,
+      email,
+      country,
+      zipCode,
+      lang = 'en',
+      utm_source,
+      utm_medium,
+      utm_campaign,
+      utm_content,
+      utm_term,
+      referrer,
+      landing_path,
+    } = await req.json()
     const l: Lang = isValidLang(lang) ? lang : 'en'
 
     if (!fullName || fullName.trim().length < 2) {
@@ -28,6 +41,13 @@ export async function POST(req: Request) {
         email_verified: false,
         country: country?.trim() || null,
         zip_code: zipCode?.trim() || null,
+        utm_source: utm_source?.slice(0, 255) || null,
+        utm_medium: utm_medium?.slice(0, 255) || null,
+        utm_campaign: utm_campaign?.slice(0, 255) || null,
+        utm_content: utm_content?.slice(0, 255) || null,
+        utm_term: utm_term?.slice(0, 255) || null,
+        referrer: referrer?.slice(0, 2048) || null,
+        landing_path: landing_path?.slice(0, 255) || null,
       })
       .select('id')
       .single()

--- a/app/components/SignupForm.tsx
+++ b/app/components/SignupForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, forwardRef, useImperativeHandle, type FormEvent } from 'react'
 import { track } from '@vercel/analytics'
 import { t, type Lang } from '@/lib/i18n'
+import { getStoredAttribution } from '@/lib/attribution'
 
 type Step = 'email' | 'details' | 'verify-email'
 
@@ -212,6 +213,8 @@ const SignupForm = forwardRef<SignupFormHandle, SignupFormProps>(function Signup
     setLoading(true)
     setError('')
 
+    const attribution = getStoredAttribution()
+
     const res = await fetch('/api/signup', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -221,6 +224,7 @@ const SignupForm = forwardRef<SignupFormHandle, SignupFormProps>(function Signup
         country,
         zipCode,
         lang,
+        ...attribution,
       }),
     })
     const data = await res.json()

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback, type MouseEvent as ReactMouseEvent } from 'react'
+import { captureAttribution } from '@/lib/attribution'
 import dynamic from 'next/dynamic'
 import { track } from '@vercel/analytics'
 import { isValidLang, LANGUAGES, t, type Lang } from '@/lib/i18n'
@@ -100,6 +101,7 @@ export default function WatchPage() {
       }
     }
     setBgQuality(getBgQuality())
+    captureAttribution()
     setIsSignedUp(!!localStorage.getItem('thm-signed-up'))
     const handler = () => setIsSignedUp(!!localStorage.getItem('thm-signed-up'))
     window.addEventListener('thm-signed-up', handler)

--- a/app/summit/page.tsx
+++ b/app/summit/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from 'next/navigation'
+
+// /summit — tracking route for Summit at Sea conference attendees.
+// Redirects to the landing page with UTM parameters attached for attribution.
+export default function SummitRedirect() {
+  redirect('/?utm_source=summit_at_sea&utm_medium=conference&utm_campaign=summit_2026')
+}

--- a/lib/attribution.ts
+++ b/lib/attribution.ts
@@ -1,0 +1,70 @@
+// Attribution helpers — capture UTMs, referrer, and landing path on first visit;
+// persist in sessionStorage so they survive navigation within the same session;
+// attach to signup submissions for last-touch attribution.
+
+const STORAGE_KEY = 'thm-attribution'
+
+export type Attribution = {
+  utm_source?: string
+  utm_medium?: string
+  utm_campaign?: string
+  utm_content?: string
+  utm_term?: string
+  referrer?: string
+  landing_path?: string
+}
+
+const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'] as const
+
+/**
+ * Capture attribution data from the current URL and document.referrer.
+ * Stores in sessionStorage on first call so it survives navigation.
+ * Safe to call repeatedly — overwrites only if new UTM params are present.
+ */
+export function captureAttribution(): Attribution {
+  if (typeof window === 'undefined') return {}
+
+  const params = new URLSearchParams(window.location.search)
+  const current: Attribution = {}
+
+  for (const key of UTM_KEYS) {
+    const value = params.get(key)
+    if (value) current[key] = value
+  }
+
+  // Only capture referrer if it's external (not our own domain)
+  if (document.referrer && !document.referrer.includes(window.location.hostname)) {
+    current.referrer = document.referrer
+  }
+
+  current.landing_path = window.location.pathname
+
+  const existing = getStoredAttribution()
+
+  // If the current URL has UTMs, update stored (last-touch wins).
+  // Otherwise keep what's already stored (preserves attribution across page navigation).
+  const hasNewUtms = UTM_KEYS.some((k) => current[k])
+  const merged = hasNewUtms ? current : { ...current, ...existing }
+
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(merged))
+  } catch {
+    // sessionStorage may be unavailable (private mode, etc.) — silently continue
+  }
+
+  return merged
+}
+
+/**
+ * Retrieve stored attribution data for inclusion in signup payload.
+ */
+export function getStoredAttribution(): Attribution {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    return JSON.parse(raw)
+  } catch {
+    return {}
+  }
+}

--- a/migrations/signup_attribution.sql
+++ b/migrations/signup_attribution.sql
@@ -1,0 +1,14 @@
+-- Add attribution columns to signups table for UTM and referrer tracking.
+-- Last-touch attribution: captures whatever UTMs were in the URL at signup time.
+
+ALTER TABLE signups ADD COLUMN IF NOT EXISTS utm_source TEXT;
+ALTER TABLE signups ADD COLUMN IF NOT EXISTS utm_medium TEXT;
+ALTER TABLE signups ADD COLUMN IF NOT EXISTS utm_campaign TEXT;
+ALTER TABLE signups ADD COLUMN IF NOT EXISTS utm_content TEXT;
+ALTER TABLE signups ADD COLUMN IF NOT EXISTS utm_term TEXT;
+ALTER TABLE signups ADD COLUMN IF NOT EXISTS referrer TEXT;
+ALTER TABLE signups ADD COLUMN IF NOT EXISTS landing_path TEXT;
+
+-- Index on utm_source for campaign reporting queries
+CREATE INDEX IF NOT EXISTS idx_signups_utm_source ON signups (utm_source);
+CREATE INDEX IF NOT EXISTS idx_signups_utm_campaign ON signups (utm_campaign);


### PR DESCRIPTION
## Summary
- Adds `/summit` route that redirects to the landing page with Summit at Sea UTM parameters attached
- Captures UTM + referrer data on all signups for last-touch attribution (addresses a Tier 1 item from the April 20 analytics report)

## Changes
- `migrations/signup_attribution.sql` — new columns on `signups`: `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `referrer`, `landing_path` (+ indexes)
- `lib/attribution.ts` — sessionStorage-backed helper that captures UTMs and referrer once per session and survives navigation within the site
- `app/page.tsx` — calls `captureAttribution()` on page load
- `app/components/SignupForm.tsx` — includes attribution fields in the `/api/signup` POST body
- `app/api/signup/route.ts` — accepts and stores the new fields on new signup rows
- `app/summit/page.tsx` — server-side redirect to `/?utm_source=summit_at_sea&utm_medium=conference&utm_campaign=summit_2026`

## Deployment notes
Run the migration on the production Supabase before (or immediately after) merge. Columns are nullable and backward-compatible, so the API will not break if the migration lags the code deploy.

```sql
-- migrations/signup_attribution.sql
ALTER TABLE signups ADD COLUMN IF NOT EXISTS utm_source TEXT;
-- ...etc.
```

## Test plan
- [ ] Preview URL loads the landing page without regression
- [ ] Visit preview URL `/summit` — confirm it redirects to `/` with the three Summit UTM params in the URL
- [ ] Complete a test signup from `/summit` on the preview URL
- [ ] After migration is run, verify the signup row has `utm_source=summit_at_sea`, `utm_medium=conference`, `utm_campaign=summit_2026`
- [ ] Visit `/` with no UTMs, sign up — confirm attribution fields are null (no junk data)

## Scope / what's not in this PR
- No custom Summit-specific content or banner (not requested)
- No dedicated email sequence for Summit signups (out of scope)
- First-touch attribution (explicitly descoped per issue #9 — can add later if reporting needs it)

Closes #9