### PR TITLE
Event RSVP system + admin UI (closes #11)

### DIFF
--- a/app/admin/events/EventForm.tsx
+++ b/app/admin/events/EventForm.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { useState, type FormEvent } from 'react'
+import { useRouter } from 'next/navigation'
+
+type Initial = {
+  slug?: string | null
+  name?: string | null
+  description?: string | null
+  starts_at?: string | null
+  ends_at?: string | null
+  location?: string | null
+  meeting_url?: string | null
+  capacity?: number | null
+  is_published?: boolean | null
+}
+
+function toLocalInputValue(iso: string | null | undefined): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  // Format as YYYY-MM-DDTHH:mm in local time for datetime-local input
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+export default function EventForm({ initial, mode }: { initial?: Initial; mode: 'create' | 'edit' }) {
+  const router = useRouter()
+  const [slug, setSlug] = useState(initial?.slug || '')
+  const [name, setName] = useState(initial?.name || '')
+  const [description, setDescription] = useState(initial?.description || '')
+  const [startsAt, setStartsAt] = useState(toLocalInputValue(initial?.starts_at))
+  const [endsAt, setEndsAt] = useState(toLocalInputValue(initial?.ends_at))
+  const [location, setLocation] = useState(initial?.location || '')
+  const [meetingUrl, setMeetingUrl] = useState(initial?.meeting_url || '')
+  const [capacity, setCapacity] = useState(initial?.capacity ? String(initial.capacity) : '')
+  const [isPublished, setIsPublished] = useState(initial?.is_published || false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+
+    const payload = {
+      slug: slug.trim(),
+      name: name.trim(),
+      description: description.trim() || null,
+      starts_at: startsAt ? new Date(startsAt).toISOString() : null,
+      ends_at: endsAt ? new Date(endsAt).toISOString() : null,
+      location: location.trim() || null,
+      meeting_url: meetingUrl.trim() || null,
+      capacity: capacity ? parseInt(capacity, 10) : null,
+      is_published: isPublished,
+    }
+
+    const url = mode === 'create' ? '/api/admin/events' : `/api/admin/events/${initial?.slug}`
+    const method = mode === 'create' ? 'POST' : 'PATCH'
+
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+
+    if (res.ok) {
+      router.push('/admin/events')
+      router.refresh()
+    } else {
+      const data = await res.json().catch(() => ({}))
+      setError(data.error || 'Save failed')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5 max-w-2xl">
+      <div>
+        <label className="block text-xs uppercase tracking-widest text-white/40 mb-2">Slug (URL)</label>
+        <input
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          required
+          disabled={mode === 'edit'}
+          placeholder="actionar"
+          pattern="[a-z0-9\-]+"
+          className="w-full bg-white/[0.05] border border-white/20 rounded-md px-4 py-2.5 text-white font-mono disabled:opacity-50"
+        />
+        <p className="text-xs text-white/40 mt-1">Lowercase letters, numbers, hyphens only. Public URL: /event/{slug || '...'}</p>
+      </div>
+
+      <div>
+        <label className="block text-xs uppercase tracking-widest text-white/40 mb-2">Name</label>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          className="w-full bg-white/[0.05] border border-white/20 rounded-md px-4 py-2.5 text-white"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs uppercase tracking-widest text-white/40 mb-2">Description (markdown)</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={8}
+          className="w-full bg-white/[0.05] border border-white/20 rounded-md px-4 py-2.5 text-white font-mono text-sm"
+        />
+        <p className="text-xs text-white/40 mt-1">Supports **bold**, *italic*, [link](url), and paragraph breaks.</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-xs uppercase tracking-widest text-white/40 mb-2">Starts at (local time)</label>
+          <input
+            type="datetime-local"
+            value={startsAt}
+            onChange={(e) => setStartsAt(e.target.value)}
+            className="w-full bg-white/[0.05] border border-white/20 rounded-md px-4 py-2.5 text-white"
+          />
+        </div>
+        <div>
+          <label className="block text-xs uppercase tracking-widest text-white/40 mb-2">Ends at (local time)</label>
+          <input
+            type="datetime-local"
+            value={endsAt}
+            onChange={(e) => setEndsAt(e.target.value)}
+            className="w-full bg-white/[0.05] border border-white/20 rounded-md px-4 py-2.5 text-white"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-xs uppercase tracking-widest text-white/40 mb-2">Location</label>
+        <input
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          placeholder="Virtual"
+          className="w-full bg-white/[0.05] border border-white/20 rounded-md px-4 py-2.5 text-white"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs uppercase tracking-widest text-white/40 mb-2">Meeting URL</label>
+        <input
+          type="url"
+          value={meetingUrl}
+          onChange={(e) => setMeetingUrl(e.target.value)}
+          placeholder="https://zoom.us/j/..."
+          className="w-full bg-white/[0.05] border border-white/20 rounded-md px-4 py-2.5 text-white"
+        />
+        <p className="text-xs text-white/40 mt-1">Included in the calendar invite. Not shown publicly until added to the .ics download.</p>
+      </div>
+
+      <div>
+        <label className="block text-xs uppercase tracking-widest text-white/40 mb-2">Capacity (optional)</label>
+        <input
+          type="number"
+          min="0"
+          value={capacity}
+          onChange={(e) => setCapacity(e.target.value)}
+          className="w-full bg-white/[0.05] border border-white/20 rounded-md px-4 py-2.5 text-white"
+        />
+      </div>
+
+      <div>
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isPublished}
+            onChange={(e) => setIsPublished(e.target.checked)}
+            className="w-5 h-5"
+          />
+          <span className="font-body text-sm">Published (visible at /event/{slug || 'slug'})</span>
+        </label>
+      </div>
+
+      <div className="flex gap-3 pt-4 border-t border-white/10">
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-sunrise text-black font-bold uppercase tracking-wider px-6 py-3 rounded-md hover:bg-sunrise/90 disabled:opacity-50"
+        >
+          {loading ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push('/admin/events')}
+          className="text-white/60 hover:text-white px-6 py-3"
+        >
+          Cancel
+        </button>
+      </div>
+
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+    </form>
+  )
+}

--- a/app/admin/events/[slug]/edit/page.tsx
+++ b/app/admin/events/[slug]/edit/page.tsx
@@ -1,0 +1,21 @@
+import { notFound } from 'next/navigation'
+import { getEventBySlug } from '@/lib/events'
+import EventForm from '../../EventForm'
+
+export const dynamic = 'force-dynamic'
+
+export default async function EditEventPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const event = await getEventBySlug(slug)
+  if (!event) notFound()
+
+  return (
+    <main className="min-h-screen bg-[#0a0a0a] text-white p-8 sm:p-12">
+      <div className="max-w-5xl mx-auto">
+        <a href="/admin/events" className="text-white/50 hover:text-white text-sm mb-4 inline-block">← Events</a>
+        <h1 className="font-serif uppercase text-3xl mb-8">Edit event</h1>
+        <EventForm mode="edit" initial={event} />
+      </div>
+    </main>
+  )
+}

--- a/app/admin/events/[slug]/rsvps/page.tsx
+++ b/app/admin/events/[slug]/rsvps/page.tsx
@@ -1,0 +1,61 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { getEventBySlug, listRsvpsForEvent } from '@/lib/events'
+
+export const dynamic = 'force-dynamic'
+
+function formatDate(s: string): string {
+  return new Date(s).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+export default async function EventRsvpsPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const event = await getEventBySlug(slug)
+  if (!event) notFound()
+  const rsvps = await listRsvpsForEvent(event.id)
+
+  return (
+    <main className="min-h-screen bg-[#0a0a0a] text-white p-8 sm:p-12">
+      <div className="max-w-5xl mx-auto">
+        <Link href="/admin/events" className="text-white/50 hover:text-white text-sm mb-4 inline-block">← Events</Link>
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="font-serif uppercase text-3xl">{event.name}</h1>
+            <p className="text-white/50 mt-1 text-sm">{rsvps.length} RSVPs</p>
+          </div>
+          <a
+            href={`/api/admin/events/${event.slug}/rsvps.csv`}
+            className="bg-sunrise text-black font-bold uppercase tracking-wider text-sm px-5 py-2.5 rounded-md hover:bg-sunrise/90 transition-colors"
+          >
+            Export CSV
+          </a>
+        </div>
+
+        {rsvps.length === 0 ? (
+          <p className="text-white/50">No RSVPs yet.</p>
+        ) : (
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-widest text-white/40 border-b border-white/10">
+                <th className="py-3">Email</th>
+                <th className="py-3">Source</th>
+                <th className="py-3">Campaign</th>
+                <th className="py-3">RSVP'd at</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rsvps.map((r) => (
+                <tr key={r.id} className="border-b border-white/5">
+                  <td className="py-3 font-mono text-sm">{r.email}</td>
+                  <td className="py-3 text-sm text-white/70">{r.utm_source || '—'}</td>
+                  <td className="py-3 text-sm text-white/70">{r.utm_campaign || '—'}</td>
+                  <td className="py-3 text-sm text-white/70">{formatDate(r.created_at)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/app/admin/events/new/page.tsx
+++ b/app/admin/events/new/page.tsx
@@ -1,0 +1,15 @@
+import EventForm from '../EventForm'
+
+export const dynamic = 'force-dynamic'
+
+export default function NewEventPage() {
+  return (
+    <main className="min-h-screen bg-[#0a0a0a] text-white p-8 sm:p-12">
+      <div className="max-w-5xl mx-auto">
+        <a href="/admin/events" className="text-white/50 hover:text-white text-sm mb-4 inline-block">← Events</a>
+        <h1 className="font-serif uppercase text-3xl mb-8">New event</h1>
+        <EventForm mode="create" />
+      </div>
+    </main>
+  )
+}

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -1,0 +1,86 @@
+import Link from 'next/link'
+import { listAllEvents } from '@/lib/events'
+
+export const dynamic = 'force-dynamic'
+
+function formatDate(s: string | null): string {
+  if (!s) return '—'
+  return new Date(s).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+export default async function AdminEventsPage() {
+  const events = await listAllEvents()
+  return (
+    <main className="min-h-screen bg-[#0a0a0a] text-white p-8 sm:p-12">
+      <div className="max-w-5xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="font-serif uppercase text-3xl">Events</h1>
+          <div className="flex gap-3">
+            <Link
+              href="/admin/events/new"
+              className="bg-sunrise text-black font-bold uppercase tracking-wider text-sm px-5 py-2.5 rounded-md hover:bg-sunrise/90 transition-colors"
+            >
+              + New event
+            </Link>
+            <form action="/api/admin/logout" method="POST">
+              <button type="submit" className="text-sm text-white/50 hover:text-white">
+                Sign out
+              </button>
+            </form>
+          </div>
+        </div>
+
+        {events.length === 0 ? (
+          <p className="text-white/50">No events yet. Create your first one.</p>
+        ) : (
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-widest text-white/40 border-b border-white/10">
+                <th className="py-3">Name</th>
+                <th className="py-3">Slug</th>
+                <th className="py-3">Starts</th>
+                <th className="py-3">Status</th>
+                <th className="py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((ev) => (
+                <tr key={ev.id} className="border-b border-white/5">
+                  <td className="py-4">{ev.name}</td>
+                  <td className="py-4 font-mono text-sm text-white/70">{ev.slug}</td>
+                  <td className="py-4 text-sm text-white/70">{formatDate(ev.starts_at)}</td>
+                  <td className="py-4">
+                    <span
+                      className={`text-xs uppercase tracking-wider px-2 py-1 rounded ${
+                        ev.is_published
+                          ? 'bg-emerald-500/20 text-emerald-300'
+                          : 'bg-white/10 text-white/60'
+                      }`}
+                    >
+                      {ev.is_published ? 'Published' : 'Draft'}
+                    </span>
+                  </td>
+                  <td className="py-4 text-right">
+                    <div className="flex gap-3 justify-end text-sm">
+                      <Link href={`/admin/events/${ev.slug}/edit`} className="text-sunrise hover:underline">
+                        Edit
+                      </Link>
+                      <Link href={`/admin/events/${ev.slug}/rsvps`} className="text-sunrise hover:underline">
+                        RSVPs
+                      </Link>
+                      {ev.is_published && (
+                        <Link href={`/event/${ev.slug}`} target="_blank" className="text-white/60 hover:underline">
+                          View
+                        </Link>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { Suspense, useState, type FormEvent } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+function LoginForm() {
+  const router = useRouter()
+  const params = useSearchParams()
+  const from = params.get('from') || '/admin/events'
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+    const res = await fetch('/api/admin/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    })
+    if (res.ok) {
+      router.push(from)
+    } else {
+      const data = await res.json().catch(() => ({}))
+      setError(data.error || 'Login failed')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+      <h1 className="font-serif uppercase text-2xl text-white mb-6">Admin login</h1>
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+        autoFocus
+        placeholder="Password"
+        className="w-full bg-white/[0.05] border border-white/20 rounded-md px-4 py-3 text-white placeholder:text-white/30 focus:border-sunrise focus:outline-none"
+        disabled={loading}
+      />
+      <button
+        type="submit"
+        disabled={loading || !password}
+        className="w-full bg-sunrise text-black font-bold uppercase tracking-wider px-6 py-3 rounded-md hover:bg-sunrise/90 disabled:opacity-50 transition-colors"
+      >
+        {loading ? 'Signing in…' : 'Sign in'}
+      </button>
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+    </form>
+  )
+}
+
+export default function AdminLoginPage() {
+  return (
+    <main className="min-h-screen bg-[#0a0a0a] text-white flex items-center justify-center px-6">
+      <Suspense fallback={<div className="text-white/40">Loading…</div>}>
+        <LoginForm />
+      </Suspense>
+    </main>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from 'next/navigation'
+
+// /admin is the landing point — send authenticated users to the events list.
+// Middleware already gates this route, so unauthed visitors get bounced to /admin/login first.
+export default function AdminIndexPage() {
+  redirect('/admin/events')
+}

--- a/app/api/admin/events/[slug]/route.ts
+++ b/app/api/admin/events/[slug]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const body = await req.json().catch(() => ({}))
+  const { name, description, starts_at, ends_at, location, meeting_url, capacity, is_published } = body
+
+  const { data, error } = await supabase
+    .from('events')
+    .update({
+      name,
+      description: description ?? null,
+      starts_at: starts_at ?? null,
+      ends_at: ends_at ?? null,
+      location: location ?? null,
+      meeting_url: meeting_url ?? null,
+      capacity: capacity ?? null,
+      is_published: !!is_published,
+    })
+    .eq('slug', slug)
+    .select()
+    .single()
+
+  if (error) {
+    console.error('Event update error:', error)
+    return NextResponse.json({ error: 'Failed to update event' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true, event: data })
+}

--- a/app/api/admin/events/[slug]/rsvps.csv/route.ts
+++ b/app/api/admin/events/[slug]/rsvps.csv/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+import { getEventBySlug, listRsvpsForEvent } from '@/lib/events'
+
+function csvEscape(value: string | null | undefined): string {
+  if (value == null) return ''
+  const s = String(value)
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`
+  return s
+}
+
+export async function GET(_req: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const event = await getEventBySlug(slug)
+  if (!event) {
+    return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+  }
+  const rsvps = await listRsvpsForEvent(event.id)
+
+  const headers = ['email', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'referrer', 'created_at']
+  const rows = [
+    headers.join(','),
+    ...rsvps.map((r) =>
+      [
+        csvEscape(r.email),
+        csvEscape(r.utm_source),
+        csvEscape(r.utm_medium),
+        csvEscape(r.utm_campaign),
+        csvEscape(r.utm_content),
+        csvEscape(r.utm_term),
+        csvEscape(r.referrer),
+        csvEscape(r.created_at),
+      ].join(',')
+    ),
+  ]
+
+  const csv = rows.join('\n') + '\n'
+
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${event.slug}-rsvps.csv"`,
+    },
+  })
+}

--- a/app/api/admin/events/route.ts
+++ b/app/api/admin/events/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+const SLUG_RE = /^[a-z0-9-]+$/
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}))
+  const { slug, name, description, starts_at, ends_at, location, meeting_url, capacity, is_published } = body
+
+  if (!slug || !SLUG_RE.test(slug)) {
+    return NextResponse.json({ error: 'Slug must be lowercase letters, numbers, and hyphens.' }, { status: 400 })
+  }
+  if (!name || typeof name !== 'string') {
+    return NextResponse.json({ error: 'Name is required.' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('events')
+    .insert({
+      slug,
+      name,
+      description: description || null,
+      starts_at: starts_at || null,
+      ends_at: ends_at || null,
+      location: location || null,
+      meeting_url: meeting_url || null,
+      capacity: capacity ?? null,
+      is_published: !!is_published,
+    })
+    .select()
+    .single()
+
+  if (error) {
+    if (error.code === '23505') {
+      return NextResponse.json({ error: 'An event with that slug already exists.' }, { status: 409 })
+    }
+    console.error('Event create error:', error)
+    return NextResponse.json({ error: 'Failed to create event' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true, event: data })
+}

--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import { verifyPassword, createSessionToken, SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS } from '@/lib/admin-auth'
+
+// Naive in-memory rate limit per process; resets on cold start.
+// Adequate for a single-tenant admin behind low traffic.
+const attempts: Map<string, { count: number; resetAt: number }> = new Map()
+const WINDOW_MS = 15 * 60 * 1000
+const MAX_ATTEMPTS = 5
+
+function rateLimit(ip: string): boolean {
+  const now = Date.now()
+  const entry = attempts.get(ip)
+  if (!entry || now > entry.resetAt) {
+    attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS })
+    return true
+  }
+  if (entry.count >= MAX_ATTEMPTS) return false
+  entry.count++
+  return true
+}
+
+export async function POST(req: Request) {
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown'
+  if (!rateLimit(ip)) {
+    return NextResponse.json({ error: 'Too many attempts. Try again later.' }, { status: 429 })
+  }
+
+  const { password } = await req.json().catch(() => ({}))
+  if (!password || typeof password !== 'string') {
+    return NextResponse.json({ error: 'Password required' }, { status: 400 })
+  }
+
+  if (!verifyPassword(password)) {
+    return NextResponse.json({ error: 'Invalid password' }, { status: 401 })
+  }
+
+  const token = await createSessionToken()
+  const res = NextResponse.json({ ok: true })
+  res.cookies.set(SESSION_COOKIE_NAME, token, SESSION_COOKIE_OPTIONS)
+  return res
+}

--- a/app/api/admin/logout/route.ts
+++ b/app/api/admin/logout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { SESSION_COOKIE_NAME } from '@/lib/admin-auth'
+
+export async function POST() {
+  const res = NextResponse.json({ ok: true })
+  res.cookies.set(SESSION_COOKIE_NAME, '', { maxAge: 0, path: '/' })
+  return res
+}

--- a/app/api/event/[slug]/ics/route.ts
+++ b/app/api/event/[slug]/ics/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import { getPublishedEventBySlug } from '@/lib/events'
+import { generateIcs } from '@/lib/ics'
+
+export async function GET(_req: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const event = await getPublishedEventBySlug(slug)
+  if (!event) {
+    return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+  }
+  if (!event.starts_at || !event.ends_at) {
+    return NextResponse.json({ error: 'Event time not set' }, { status: 400 })
+  }
+
+  const ics = generateIcs({
+    uid: `${event.id}@thehumanmovement.org`,
+    summary: event.name,
+    description: event.description || undefined,
+    location: event.meeting_url || event.location || undefined,
+    url: event.meeting_url || undefined,
+    start: new Date(event.starts_at),
+    end: new Date(event.ends_at),
+  })
+
+  return new NextResponse(ics, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/calendar; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${event.slug}.ics"`,
+    },
+  })
+}

--- a/app/api/event/[slug]/rsvp/route.ts
+++ b/app/api/event/[slug]/rsvp/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import { getPublishedEventBySlug } from '@/lib/events'
+
+export async function POST(req: Request, { params }: { params: Promise<{ slug: string }> }) {
+  try {
+    const { slug } = await params
+    const body = await req.json()
+    const { email, utm_source, utm_medium, utm_campaign, utm_content, utm_term, referrer } = body
+
+    if (!email || typeof email !== 'string' || !email.includes('@')) {
+      return NextResponse.json({ error: 'Valid email required' }, { status: 400 })
+    }
+
+    const event = await getPublishedEventBySlug(slug)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    const { error } = await supabase.from('event_rsvps').insert({
+      event_id: event.id,
+      email: email.trim().toLowerCase(),
+      utm_source: utm_source?.slice(0, 255) || null,
+      utm_medium: utm_medium?.slice(0, 255) || null,
+      utm_campaign: utm_campaign?.slice(0, 255) || null,
+      utm_content: utm_content?.slice(0, 255) || null,
+      utm_term: utm_term?.slice(0, 255) || null,
+      referrer: referrer?.slice(0, 2048) || null,
+    })
+
+    if (error) {
+      // Unique-constraint violation = already RSVPed; treat as success (idempotent)
+      if (error.code === '23505') {
+        return NextResponse.json({ ok: true, alreadyRsvped: true })
+      }
+      console.error('RSVP insert error:', error)
+      return NextResponse.json({ error: 'Failed to save RSVP' }, { status: 500 })
+    }
+
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('RSVP route error:', err)
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+}

--- a/app/event/[slug]/AddToCalendar.tsx
+++ b/app/event/[slug]/AddToCalendar.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+export default function AddToCalendar({ slug }: { slug: string }) {
+  return (
+    <a
+      href={`/api/event/${slug}/ics`}
+      className="inline-flex items-center gap-2 font-body text-sm text-white/70 hover:text-white border border-white/20 hover:border-white/40 rounded-full px-5 py-2.5 transition-colors"
+    >
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
+      </svg>
+      Add to calendar
+    </a>
+  )
+}

--- a/app/event/[slug]/EventRsvpForm.tsx
+++ b/app/event/[slug]/EventRsvpForm.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useState, useEffect, type FormEvent } from 'react'
+import { captureAttribution, getStoredAttribution } from '@/lib/attribution'
+
+export default function EventRsvpForm({ slug }: { slug: string }) {
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [done, setDone] = useState(false)
+
+  useEffect(() => {
+    captureAttribution()
+  }, [])
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!email.trim()) return
+    setLoading(true)
+    setError('')
+
+    const attribution = getStoredAttribution()
+    const res = await fetch(`/api/event/${slug}/rsvp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email.trim(), ...attribution }),
+    })
+
+    if (res.ok) {
+      setDone(true)
+    } else {
+      const data = await res.json().catch(() => ({}))
+      setError(data.error || 'Something went wrong. Please try again.')
+    }
+    setLoading(false)
+  }
+
+  if (done) {
+    return (
+      <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-6 py-5">
+        <p className="font-serif uppercase text-xl text-white mb-2">You're in.</p>
+        <p className="font-body text-sm text-white/70">
+          We'll send you a reminder closer to the event. Check your inbox for confirmation details.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <p className="font-serif uppercase text-2xl sm:text-3xl text-white">RSVP</p>
+      <p className="font-body text-sm text-white/60 mb-2">
+        Drop your email and we'll send you a reminder before the event.
+      </p>
+      <div className="flex flex-col sm:flex-row gap-3">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          placeholder="your@email.com"
+          className="flex-1 bg-white/[0.05] border border-white/20 rounded-md px-4 py-3 text-white placeholder:text-white/30 focus:border-sunrise focus:outline-none font-body"
+          disabled={loading || done}
+        />
+        <button
+          type="submit"
+          disabled={loading || !email.trim()}
+          className="bg-sunrise text-black font-body font-bold uppercase tracking-wider px-6 py-3 rounded-md hover:bg-sunrise/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {loading ? 'RSVPing…' : 'RSVP'}
+        </button>
+      </div>
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+    </form>
+  )
+}

--- a/app/event/[slug]/page.tsx
+++ b/app/event/[slug]/page.tsx
@@ -1,0 +1,85 @@
+import { notFound } from 'next/navigation'
+import { getPublishedEventBySlug } from '@/lib/events'
+import EventRsvpForm from './EventRsvpForm'
+import AddToCalendar from './AddToCalendar'
+
+export const dynamic = 'force-dynamic'
+
+function renderMarkdown(md: string): string {
+  // Minimal markdown: bold (**text**), italic (*text*), links, paragraphs.
+  // Avoids pulling in a markdown library for v1.
+  let html = md
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+  html = html.replace(/(^|[^*])\*([^*]+)\*/g, '$1<em>$2</em>')
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer" class="underline">$1</a>')
+  // Paragraphs split on blank lines
+  const paragraphs = html.split(/\n\s*\n/).map((p) => `<p class="mb-4">${p.replace(/\n/g, '<br/>')}</p>`)
+  return paragraphs.join('\n')
+}
+
+function formatEventTime(starts_at: string | null, ends_at: string | null): string | null {
+  if (!starts_at) return null
+  const start = new Date(starts_at)
+  const end = ends_at ? new Date(ends_at) : null
+  const dateOpts: Intl.DateTimeFormatOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
+  const timeOpts: Intl.DateTimeFormatOptions = { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' }
+  const datePart = start.toLocaleDateString('en-US', dateOpts)
+  const startTime = start.toLocaleTimeString('en-US', timeOpts)
+  if (!end) return `${datePart} · ${startTime}`
+  const endTime = end.toLocaleTimeString('en-US', timeOpts)
+  return `${datePart} · ${startTime} – ${endTime}`
+}
+
+export default async function EventPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const event = await getPublishedEventBySlug(slug)
+  if (!event) notFound()
+
+  const timeStr = formatEventTime(event.starts_at, event.ends_at)
+  const canDownloadIcs = !!(event.starts_at && event.ends_at)
+
+  return (
+    <main className="min-h-screen bg-[#0a0a0a] text-white px-6 py-20 sm:py-28">
+      <div className="max-w-2xl mx-auto">
+        <p className="font-body text-xs uppercase tracking-[0.2em] text-white/40 mb-4">The Human Movement</p>
+
+        <h1 className="font-serif uppercase text-4xl sm:text-5xl lg:text-6xl text-white leading-tight mb-8">
+          {event.name}
+        </h1>
+
+        {timeStr && (
+          <div className="font-body text-base sm:text-lg text-sunrise mb-2">{timeStr}</div>
+        )}
+        {event.location && (
+          <div className="font-body text-sm sm:text-base text-white/60 mb-8">{event.location}</div>
+        )}
+
+        {event.description && (
+          <div
+            className="font-body text-base sm:text-lg text-white/80 leading-relaxed mb-10"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(event.description) }}
+          />
+        )}
+
+        <div className="border-t border-white/10 pt-10">
+          <EventRsvpForm slug={event.slug} />
+        </div>
+
+        {canDownloadIcs && (
+          <div className="mt-8">
+            <AddToCalendar slug={event.slug} />
+          </div>
+        )}
+
+        <div className="mt-16 pt-8 border-t border-white/10">
+          <a href="/" className="font-body text-sm text-white/40 hover:text-white/70 transition-colors">
+            ← Back to The Human Movement
+          </a>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,0 +1,86 @@
+// Single-password admin auth.
+// Works in both Edge Runtime (middleware) and Node Runtime (API routes) by
+// using Web Crypto (subtle.sign) which is available in both.
+
+import { cookies } from 'next/headers'
+
+const COOKIE_NAME = 'thm-admin-session'
+const SESSION_TTL_SECONDS = 60 * 60 * 8 // 8 hours
+
+function getSecret(): string {
+  const s = process.env.ADMIN_SESSION_SECRET
+  if (!s || s.length < 32) {
+    throw new Error('ADMIN_SESSION_SECRET env var must be set (32+ chars)')
+  }
+  return s
+}
+
+function hexEncode(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+async function hmacHex(secret: string, payload: string): Promise<string> {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(payload))
+  return hexEncode(sig)
+}
+
+// Constant-time string comparison (works in Edge Runtime — no Buffer/Node crypto).
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let result = 0
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return result === 0
+}
+
+export function verifyPassword(input: string): boolean {
+  const expected = process.env.ADMIN_PASSWORD || ''
+  if (!expected) return false
+  return constantTimeEqual(input, expected)
+}
+
+export async function createSessionToken(): Promise<string> {
+  const expiresAt = Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS
+  const payload = `admin:${expiresAt}`
+  const sig = await hmacHex(getSecret(), payload)
+  return `${payload}:${sig}`
+}
+
+export async function verifySessionToken(token: string | undefined): Promise<boolean> {
+  if (!token) return false
+  const parts = token.split(':')
+  if (parts.length !== 3) return false
+  const [user, expiresAt, sig] = parts
+  if (user !== 'admin') return false
+  const expectedSig = await hmacHex(getSecret(), `${user}:${expiresAt}`)
+  if (!constantTimeEqual(sig, expectedSig)) return false
+  const exp = parseInt(expiresAt, 10)
+  if (!Number.isFinite(exp) || Date.now() / 1000 > exp) return false
+  return true
+}
+
+export async function isAuthenticated(): Promise<boolean> {
+  const store = await cookies()
+  const token = store.get(COOKIE_NAME)?.value
+  return verifySessionToken(token)
+}
+
+export const SESSION_COOKIE_NAME = COOKIE_NAME
+export const SESSION_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: true,
+  sameSite: 'lax' as const,
+  path: '/',
+  maxAge: SESSION_TTL_SECONDS,
+}

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,83 @@
+// Server-side event data access. Uses the existing Supabase client.
+
+import { supabase } from './supabase'
+
+export type Event = {
+  id: string
+  slug: string
+  name: string
+  description: string | null
+  starts_at: string | null
+  ends_at: string | null
+  location: string | null
+  meeting_url: string | null
+  capacity: number | null
+  is_published: boolean
+  created_at: string
+  updated_at: string
+}
+
+export type EventRsvp = {
+  id: number
+  event_id: string
+  email: string
+  utm_source: string | null
+  utm_medium: string | null
+  utm_campaign: string | null
+  utm_content: string | null
+  utm_term: string | null
+  referrer: string | null
+  created_at: string
+}
+
+export async function getPublishedEventBySlug(slug: string): Promise<Event | null> {
+  const { data, error } = await supabase
+    .from('events')
+    .select('*')
+    .eq('slug', slug)
+    .eq('is_published', true)
+    .maybeSingle()
+  if (error) {
+    console.error('getPublishedEventBySlug error:', error)
+    return null
+  }
+  return data as Event | null
+}
+
+export async function getEventBySlug(slug: string): Promise<Event | null> {
+  const { data, error } = await supabase
+    .from('events')
+    .select('*')
+    .eq('slug', slug)
+    .maybeSingle()
+  if (error) {
+    console.error('getEventBySlug error:', error)
+    return null
+  }
+  return data as Event | null
+}
+
+export async function listAllEvents(): Promise<Event[]> {
+  const { data, error } = await supabase
+    .from('events')
+    .select('*')
+    .order('created_at', { ascending: false })
+  if (error) {
+    console.error('listAllEvents error:', error)
+    return []
+  }
+  return (data || []) as Event[]
+}
+
+export async function listRsvpsForEvent(eventId: string): Promise<EventRsvp[]> {
+  const { data, error } = await supabase
+    .from('event_rsvps')
+    .select('*')
+    .eq('event_id', eventId)
+    .order('created_at', { ascending: false })
+  if (error) {
+    console.error('listRsvpsForEvent error:', error)
+    return []
+  }
+  return (data || []) as EventRsvp[]
+}

--- a/lib/ics.ts
+++ b/lib/ics.ts
@@ -1,0 +1,59 @@
+// Minimal RFC 5545 ICS generator. No external dependency.
+// Used to generate downloadable calendar invites for events.
+
+function escapeIcsText(text: string): string {
+  // RFC 5545 §3.3.11
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '')
+}
+
+function formatIcsDate(date: Date): string {
+  // Format: YYYYMMDDTHHMMSSZ (UTC)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return (
+    date.getUTCFullYear().toString() +
+    pad(date.getUTCMonth() + 1) +
+    pad(date.getUTCDate()) +
+    'T' +
+    pad(date.getUTCHours()) +
+    pad(date.getUTCMinutes()) +
+    pad(date.getUTCSeconds()) +
+    'Z'
+  )
+}
+
+export type IcsEvent = {
+  uid: string
+  summary: string
+  description?: string
+  location?: string
+  url?: string
+  start: Date
+  end: Date
+}
+
+export function generateIcs(event: IcsEvent): string {
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//The Human Movement//Event RSVP//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${event.uid}`,
+    `DTSTAMP:${formatIcsDate(new Date())}`,
+    `DTSTART:${formatIcsDate(event.start)}`,
+    `DTEND:${formatIcsDate(event.end)}`,
+    `SUMMARY:${escapeIcsText(event.summary)}`,
+  ]
+  if (event.description) lines.push(`DESCRIPTION:${escapeIcsText(event.description)}`)
+  if (event.location) lines.push(`LOCATION:${escapeIcsText(event.location)}`)
+  if (event.url) lines.push(`URL:${event.url}`)
+  lines.push('END:VEVENT', 'END:VCALENDAR')
+  // RFC 5545 mandates CRLF line endings
+  return lines.join('\r\n') + '\r\n'
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,29 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { verifySessionToken, SESSION_COOKIE_NAME } from '@/lib/admin-auth'
+
+// Protect /admin/* routes (except /admin/login itself).
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl
+
+  // Login page and login API are public
+  if (pathname === '/admin/login' || pathname === '/api/admin/login') {
+    return NextResponse.next()
+  }
+
+  if (pathname.startsWith('/admin') || pathname.startsWith('/api/admin')) {
+    const token = req.cookies.get(SESSION_COOKIE_NAME)?.value
+    const valid = await verifySessionToken(token)
+    if (!valid) {
+      const url = req.nextUrl.clone()
+      url.pathname = '/admin/login'
+      url.search = `?from=${encodeURIComponent(pathname)}`
+      return NextResponse.redirect(url)
+    }
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/admin/:path*', '/api/admin/:path*'],
+}

--- a/migrations/events.sql
+++ b/migrations/events.sql
@@ -1,0 +1,92 @@
+-- Events table — drives the /event/[slug] dynamic route.
+-- Editable via admin UI without a deploy.
+CREATE TABLE IF NOT EXISTS events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  description TEXT,                   -- markdown rendered on the public page
+  starts_at TIMESTAMPTZ,
+  ends_at TIMESTAMPTZ,
+  location TEXT,                      -- "Virtual" or physical address
+  meeting_url TEXT,                   -- Zoom/Google Meet link, included in confirmation
+  capacity INT,                       -- null = unlimited
+  is_published BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_slug ON events (slug);
+CREATE INDEX IF NOT EXISTS idx_events_starts_at ON events (starts_at);
+
+-- Auto-update updated_at on row changes
+CREATE OR REPLACE FUNCTION update_events_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_events_updated_at ON events;
+CREATE TRIGGER trg_events_updated_at
+  BEFORE UPDATE ON events
+  FOR EACH ROW
+  EXECUTE FUNCTION update_events_updated_at();
+
+-- Event RSVPs table
+CREATE TABLE IF NOT EXISTS event_rsvps (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  utm_source TEXT,
+  utm_medium TEXT,
+  utm_campaign TEXT,
+  utm_content TEXT,
+  utm_term TEXT,
+  referrer TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(event_id, email)
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_rsvps_event_id ON event_rsvps (event_id);
+CREATE INDEX IF NOT EXISTS idx_event_rsvps_created_at ON event_rsvps (created_at DESC);
+
+-- RLS: public can insert RSVPs (the API does this with the anon key);
+-- only authenticated/service can read events and RSVPs.
+ALTER TABLE events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE event_rsvps ENABLE ROW LEVEL SECURITY;
+
+-- Public can read published events (needed for the public /event/[slug] page using anon key)
+DROP POLICY IF EXISTS "Public can read published events" ON events;
+CREATE POLICY "Public can read published events" ON events
+  FOR SELECT
+  USING (is_published = true);
+
+-- Service role has full access for admin UI (uses service_role key)
+DROP POLICY IF EXISTS "Service role full access events" ON events;
+CREATE POLICY "Service role full access events" ON events
+  FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- Public can insert RSVPs
+DROP POLICY IF EXISTS "Public can insert RSVPs" ON event_rsvps;
+CREATE POLICY "Public can insert RSVPs" ON event_rsvps
+  FOR INSERT
+  WITH CHECK (true);
+
+-- Only service role can read RSVPs (used by admin UI)
+DROP POLICY IF EXISTS "Service role can read RSVPs" ON event_rsvps;
+CREATE POLICY "Service role can read RSVPs" ON event_rsvps
+  FOR SELECT
+  USING (auth.role() = 'service_role');
+
+-- Seed the actionar event (unpublished — team fills in copy before publishing)
+INSERT INTO events (slug, name, description, location, is_published)
+VALUES (
+  'actionar',
+  'The Actionar',
+  '**Description coming soon.** This event is currently a draft. Update the description, time, and meeting link via the admin UI before publishing.',
+  'Virtual',
+  false
+)
+ON CONFLICT (slug) DO NOTHING;


### PR DESCRIPTION
## Summary
Generic `/event/[slug]` route with a password-protected admin UI for the team to manage events without Supabase access. First seeded event: actionar.

## What ships
- Public RSVP page at `/event/[slug]` with branded layout, markdown description, RSVP form, and `.ics` calendar download
- RSVP API (`/api/event/[slug]/rsvp`) with attribution capture and idempotent duplicate handling
- Admin UI at `/admin/events`: list, create, edit, publish toggle, RSVP viewer, CSV export
- Single-password auth with 8-hour session cookie, rate-limited login
- Migration: `events` and `event_rsvps` tables + RLS policies + seed actionar row as draft

## Deployment steps (in order)

### 1. Add new env vars to Vercel
Both Production and Preview need:
- `ADMIN_PASSWORD` — pick a strong password, share with the team
- `ADMIN_SESSION_SECRET` — 32+ char random string (e.g. from `openssl rand -hex 32`). This signs the session cookie; keep it secret.

### 2. Run the migration on production Supabase
Paste `migrations/events.sql` into the Supabase SQL Editor and run. Idempotent: safe to re-run. Creates two tables, an updated_at trigger, RLS policies, and seeds the actionar event as a draft.

### 3. Merge this PR
Vercel auto-deploys. The actionar event lives at `/event/actionar` but won't render until step 4.

### 4. Fill in the actionar copy
Sign in at `/admin/login`, edit the actionar event, fill in description, time, meeting URL, then toggle Published. The page goes live immediately.

## Test plan
- [ ] Migration runs cleanly on production Supabase
- [ ] `/admin/login` rejects wrong password and accepts correct one
- [ ] After login, `/admin/events` shows the seeded actionar (Draft)
- [ ] Edit the actionar, set time and description, toggle published
- [ ] Visit `/event/actionar` — page renders with content
- [ ] Submit an RSVP from the public page — confirmation shows
- [ ] Visit `/admin/events/actionar/rsvps` — RSVP appears in the list
- [ ] Export CSV — file downloads with the RSVP
- [ ] `Add to calendar` button (when starts_at + ends_at set) downloads a working `.ics` file
- [ ] Sign out — `/admin/events` redirects back to login

## Out of scope (per #11)
- Per-user admin accounts
- Reminder email worker
- Capacity enforcement / waitlist
- Admin UI for other tables (signups, contact_messages)

Closes #11